### PR TITLE
Add OpenSpec proposal to migrate UI from Textual to pygame

### DIFF
--- a/openspec/changes/update-ui-pygame/design.md
+++ b/openspec/changes/update-ui-pygame/design.md
@@ -1,0 +1,29 @@
+## Context
+The current UI uses Textual, but the target experience is a pygame-based graphical application. The simulation core should remain UI-agnostic.
+
+## Goals / Non-Goals
+- Goals:
+  - Use pygame for rendering and input handling.
+  - Preserve existing gameplay flows and screen content.
+  - Keep the simulation core independent of the UI framework.
+- Non-Goals:
+  - Redesign gameplay systems or simulation rules.
+  - Add new gameplay features beyond the existing MVP screens.
+
+## Decisions
+- Decision: Introduce pygame as the UI framework.
+  - Why: It provides the desired graphical runtime and input handling.
+- Decision: Implement a scene-based UI structure that mirrors the existing Textual screens.
+  - Why: It minimizes behavioral changes while swapping the UI technology.
+
+## Risks / Trade-offs
+- Risk: pygame introduces a new dependency and runtime requirements.
+  - Mitigation: Keep the dependency scope limited to the UI layer.
+
+## Migration Plan
+1. Add pygame application bootstrap and main loop.
+2. Replace Textual screens with pygame scenes in parity with the existing flow.
+3. Remove Textual entrypoints once pygame UI is functional.
+
+## Open Questions
+- Should mouse input be supported alongside keyboard controls for the MVP?

--- a/openspec/changes/update-ui-pygame/proposal.md
+++ b/openspec/changes/update-ui-pygame/proposal.md
@@ -1,0 +1,14 @@
+# Change: Migrate UI from Textual to pygame
+
+## Why
+The current Textual-based UI does not meet the goal of delivering a pygame game experience.
+Migrating the UI layer to pygame allows the game to run as a graphical application while keeping the simulation core unchanged.
+
+## What Changes
+- Replace the Textual UI layer with a pygame-driven UI.
+- Preserve existing navigation, booking flow, and results presentation behavior.
+- Keep the simulation core UI-agnostic while changing the presentation layer.
+
+## Impact
+- Affected specs: ui
+- Affected code: UI layer modules, main entrypoint, and any Textual screen implementations

--- a/openspec/changes/update-ui-pygame/specs/ui/spec.md
+++ b/openspec/changes/update-ui-pygame/specs/ui/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+### Requirement: Textual MVP screens
+The system SHALL provide the MVP screens defined in the PRD using pygame rendering and input handling. The roster screen SHALL read from the session roster stored in `GameState` and rebuild its list rows on resume without reusing mounted widget IDs.
+
+#### Scenario: Navigate from main menu to booking hub
+- **WHEN** the player selects New Game on the main menu
+- **THEN** the booking hub screen is shown
+
+#### Scenario: Roster refresh after resume
+- **WHEN** the user returns to the roster screen after leaving it
+- **THEN** the roster list is rebuilt from the session roster without duplicate widget IDs

--- a/openspec/changes/update-ui-pygame/tasks.md
+++ b/openspec/changes/update-ui-pygame/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+- [ ] 1.1 Inventory current Textual screens and map them to pygame views/scenes
+- [ ] 1.2 Implement pygame application loop and input handling
+- [ ] 1.3 Recreate booking hub, match booking, roster, and results screens in pygame
+- [ ] 1.4 Wire pygame UI actions to existing simulation/game-state APIs
+- [ ] 1.5 Add/adjust tests or smoke checks for pygame UI startup


### PR DESCRIPTION
### Motivation
- Replace the current Textual-based presentation layer with a pygame-driven graphical UI to deliver a desktop game experience.
- Preserve the existing simulation core and gameplay flows by keeping the simulation UI-agnostic during the migration.
- Capture design, tasks, and spec deltas so the migration can be planned and reviewed via the project's OpenSpec workflow.

### Description
- Added an OpenSpec change under `openspec/changes/update-ui-pygame` including `proposal.md`, `design.md`, and `tasks.md` to document goals, decisions, and an implementation checklist.
- Added a UI spec delta at `openspec/changes/update-ui-pygame/specs/ui/spec.md` that modifies the MVP requirement to require `pygame` rendering and input handling.
- The proposal defines a scene-based UI approach that mirrors existing Textual screens and emphasizes minimal changes to the simulation core.
- No simulation or game logic files were changed in this change; the work is scoped to planning and specification artifacts for the UI migration.

### Testing
- No automated tests were executed as part of this change because the `openspec` CLI was not available in the environment to run `openspec validate`.
- No unit or integration tests were modified or run by this change.
- Validation and smoke tests for the pygame startup and UI scenes are listed in `openspec/changes/update-ui-pygame/tasks.md` and remain to be executed during implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962ffb4850c8329ad0e1800d5179196)